### PR TITLE
Fix compatibility with Xcode 12.5 

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import parser_combinator_swiftTests
-
-var tests = [XCTestCaseEntry]()
-tests += parser_combinator_swiftTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
LinuxMain.swift is from old Xcode template, so it can not build with the latest Xcode 12.5.
This pull request removes LinuxMain.swift that causes error.