### PR TITLE
Update Quick and Nimble

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Quick.git", from: "1.3.1"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.1"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "4.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Update the dependent package settings to use Quick 4.0.0 and Nimble 9.0.0 or higher versions.