### PR TITLE
Update swift-tool-version 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Update swift-tool-version to 5.2 or higher to avoid packages loaded in the test target from affecting the Package Dependencies of the host app project.