### PR TITLE
BLANC-857 Privacy Manifestsの追加

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
## JIRA
https://chatwork.atlassian.net/browse/BLANC-857

## 対応内容
- 設定値をまとめたドキュメントを作成した
  - https://chatwork.atlassian.net/wiki/spaces/MOBILE/pages/3885630247/parser-combinator-swift+-+Privacy+Manifests
- `parser-combinator-swift`をChatwork内にforkした
- `parser-combinator-swift`をPrivacy Manifests対応させた

## 重点的にレビューしてほしいところ・気になっているところ
- 設定値が合っているか
- Privacy Manifestsファイルを追加する位置が合っているか

## その他
今回、本パッケージをChatwork内にforkしたため、Privacy Manifests対応版の本パッケージを使うにはChatworkSyntax内で本パッケージを指定しているパスを書き換える必要がありそうだと考えている